### PR TITLE
[opt] Optimizing Shoup's MulMod in Apple M1/M2 chip.

### DIFF
--- a/src/prime64/less_than_62bit.rs
+++ b/src/prime64/less_than_62bit.rs
@@ -113,6 +113,53 @@ pub(crate) fn fwd_last_butterfly_avx2(
     )
 }
 
+#[cfg(any(target_arch = "aarch64"))]
+#[inline(always)]
+pub(crate) fn fwd_butterfly_scalar(
+    z0: u64,
+    z1: u64,
+    w: u64,
+    w_shoup: u64,
+    p: u64,
+    neg_p: u64,
+    two_p: u64,
+) -> (u64, u64) {
+    let _ = p;
+    let z0 = z0.min(z0.wrapping_sub(two_p));
+
+    let shoup_q_u128 = (z1 as u128 * w_shoup as u128) >> 64;
+    let t = ((z1 as u128 * w as u128) + (shoup_q_u128 * neg_p as u128)) as u64;
+
+    (z0.wrapping_add(t), z0.wrapping_sub(t).wrapping_add(two_p))
+}
+
+#[cfg(any(target_arch = "aarch64"))]
+#[inline(always)]
+pub(crate) fn fwd_last_butterfly_scalar(
+    z0: u64,
+    z1: u64,
+    w: u64,
+    w_shoup: u64,
+    p: u64,
+    neg_p: u64,
+    two_p: u64,
+) -> (u64, u64) {
+    let _ = p;
+    let z0 = z0.min(z0.wrapping_sub(two_p));
+    let z0 = z0.min(z0.wrapping_sub(p));
+
+    let shoup_q_u128 = (z1 as u128 * w_shoup as u128) >> 64;
+    let t = ((z1 as u128 * w as u128) + (shoup_q_u128 * neg_p as u128)) as u64;
+
+    let t = t.min(t.wrapping_sub(p));
+    let res = (z0.wrapping_add(t), z0.wrapping_sub(t).wrapping_add(p));
+    (
+        res.0.min(res.0.wrapping_sub(p)),
+        res.1.min(res.1.wrapping_sub(p)),
+    )
+}
+
+#[cfg(not(target_arch = "aarch64"))]
 #[inline(always)]
 pub(crate) fn fwd_butterfly_scalar(
     z0: u64,
@@ -130,6 +177,7 @@ pub(crate) fn fwd_butterfly_scalar(
     (z0.wrapping_add(t), z0.wrapping_sub(t).wrapping_add(two_p))
 }
 
+#[cfg(not(target_arch = "aarch64"))]
 #[inline(always)]
 pub(crate) fn fwd_last_butterfly_scalar(
     z0: u64,
@@ -267,6 +315,55 @@ pub(crate) fn inv_last_butterfly_avx2(
     (y0, y1)
 }
 
+#[cfg(any(target_arch = "aarch64"))]
+#[inline(always)]
+pub(crate) fn inv_butterfly_scalar(
+    z0: u64,
+    z1: u64,
+    w: u64,
+    w_shoup: u64,
+    p: u64,
+    neg_p: u64,
+    two_p: u64,
+) -> (u64, u64) {
+    let _ = p;
+
+    let y0 = z0.wrapping_add(z1);
+    let y0 = y0.min(y0.wrapping_sub(two_p));
+    let t = z0.wrapping_sub(z1).wrapping_add(two_p);
+
+    let shoup_q_u128 = (t as u128 * w_shoup as u128) >> 64;
+    let y1 = ((t as u128 * w as u128) + shoup_q_u128 * neg_p as u128) as u64;
+
+    (y0, y1)
+}
+
+#[cfg(any(target_arch = "aarch64"))]
+#[inline(always)]
+pub(crate) fn inv_last_butterfly_scalar(
+    z0: u64,
+    z1: u64,
+    w: u64,
+    w_shoup: u64,
+    p: u64,
+    neg_p: u64,
+    two_p: u64,
+) -> (u64, u64) {
+    let _ = p;
+
+    let y0 = z0.wrapping_add(z1);
+    let y0 = y0.min(y0.wrapping_sub(two_p));
+    let y0 = y0.min(y0.wrapping_sub(p));
+    let t = z0.wrapping_sub(z1).wrapping_add(two_p);
+
+    let shoup_q_u128 = (t as u128 * w_shoup as u128) >> 64;
+    let y1 = ((t as u128 * w as u128) + shoup_q_u128 * neg_p as u128) as u64;
+
+    let y1 = y1.min(y1.wrapping_sub(p));
+    (y0, y1)
+}
+
+#[cfg(not(target_arch = "aarch64"))]
 #[inline(always)]
 pub(crate) fn inv_butterfly_scalar(
     z0: u64,
@@ -287,6 +384,7 @@ pub(crate) fn inv_butterfly_scalar(
     (y0, y1)
 }
 
+#[cfg(not(target_arch = "aarch64"))]
 #[inline(always)]
 pub(crate) fn inv_last_butterfly_scalar(
     z0: u64,


### PR DESCRIPTION
**Math behind Shoup's MulMod trick**:
1.  z = mul_h64(x * y_prime) 
2.  r = x * y - z * p  // mod 2^64 implicitly
3. (Optional) reduce `r` from [0, 2p) to [0, p) 

We found that the the multiplication in Step 2 is faster when doing in u128 than in  u64 under Apple M1/M2. 
This findings are only for the u64 prime, and is not working for u32 prime. 

Here is the benchmarks.
SPEC: MacBook Pro 2022, Apple M2, 16 GB RAM. macOS 14.2.1

```
Running benches/ntt.rs (target/release/deps/ntt-7052c42fe5c957b6)
fwd-64-4611686018427322369-4096
                        time:   [14.998 µs 15.067 µs 15.166 µs]
                        change: [-27.234% -25.010% -23.685%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  5 (5.00%) low severe
  5 (5.00%) high mild
  9 (9.00%) high severe

inv-64-4611686018427322369-4096
                        time:   [14.614 µs 14.729 µs 14.895 µs]
                        change: [-31.587% -30.396% -29.322%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) high mild
  11 (11.00%) high severe

fwd-64-9223372036853661697-4096
                        time:   [15.615 µs 15.655 µs 15.705 µs]
                        change: [-36.233% -35.386% -34.617%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) high mild
  13 (13.00%) high severe

inv-64-9223372036853661697-4096
                        time:   [15.353 µs 15.380 µs 15.414 µs]
                        change: [-35.897% -35.730% -35.557%] (p = 0.00 < 0.05)
                        Performance has improved.
```